### PR TITLE
document-scoped retrieval (All docs vs Selected PDF)

### DIFF
--- a/backend/src/app/api.py
+++ b/backend/src/app/api.py
@@ -19,7 +19,7 @@ except Exception:
 
 
 app = FastAPI(
-    title="Class 12 Multi-Agent RAG Demo",
+    title="IntelliRAG Backend API",
     description="Demo API for asking questions + indexing PDFs.",
     version="0.1.0",
 )
@@ -83,7 +83,7 @@ async def qa_endpoint(payload: QuestionRequest) -> QAResponse:
             detail="`question` must be a non-empty string.",
         )
 
-    result = answer_question(question)
+    result = answer_question(question, document_scope=payload.document_scope)
 
     citations = result.get("citations") or None
     confidence = result.get("confidence", "low")

--- a/backend/src/app/core/agents/graph.py
+++ b/backend/src/app/core/agents/graph.py
@@ -90,7 +90,16 @@ def get_qa_graph() -> Any:
     return create_qa_graph()
 
 
-def run_qa_flow(question: str) -> QAState:
+def run_qa_flow(question: str, document_scope: str | None = None) -> QAState:
+    """
+    Run LangGraph QA flow with optional document scoping.
+
+    Args:
+        question:
+            User question.
+        document_scope:
+            If provided, retrieval is restricted to this specific PDF source.
+    """
     graph = get_qa_graph()
 
     initial_state: QAState = {
@@ -100,6 +109,7 @@ def run_qa_flow(question: str) -> QAState:
         "draft_answer": None,
         "answer": None,
         "confidence": "low",
+        "document_scope": document_scope,
     }
 
     final_state: QAState = graph.invoke(initial_state)
@@ -109,8 +119,6 @@ def run_qa_flow(question: str) -> QAState:
 
     answer = (final_state.get("answer") or "").strip()
 
-    # Only do cleaning if we actually have allowed IDs
-    # (If no citations returned, do not “delete” citations and confuse debugging.)
     if allowed_ids:
         answer = _remove_unknown_citations(answer, allowed_ids)
         answer = _dedupe_and_limit_per_sentence(answer, max_per_sentence=2)

--- a/backend/src/app/core/agents/state.py
+++ b/backend/src/app/core/agents/state.py
@@ -1,4 +1,6 @@
-"""LangGraph state schema for the multi-agent QA flow."""
+"""LangGraph state schema for the multi-agent QA flow.
+- document_scope: if set, retrieval should only use a specific PDF.
+"""
 
 from __future__ import annotations
 from typing import Dict, NotRequired, TypedDict
@@ -10,5 +12,6 @@ class QAState(TypedDict):
     citations: Dict[str, dict] | None
     draft_answer: str | None
     answer: str | None
+    document_scope: NotRequired[str | None]
     confidence: NotRequired[str]
     

--- a/backend/src/app/core/agents/tools.py
+++ b/backend/src/app/core/agents/tools.py
@@ -12,6 +12,13 @@ from ..retrieval.vector_store import retrieve
 
 
 def _doc_dedupe_key(doc: Document) -> str:
+    """
+    Create a deterministic key for a document chunk to remove duplicates.
+
+    Why:
+    - Splitters often create overlapping chunks
+    - Retrieval may return repeated chunks across queries
+    """
     md = doc.metadata or {}
     source = str(md.get("source", "unknown"))
     page_label = str(md.get("page_label", md.get("page", "unknown")))
@@ -23,6 +30,7 @@ def _doc_dedupe_key(doc: Document) -> str:
 
 
 def _dedupe_docs(docs: List[Document]) -> List[Document]:
+    """Remove exact duplicates based on _doc_dedupe_key."""
     seen = set()
     out: List[Document] = []
     for d in docs:
@@ -39,11 +47,19 @@ def retrieval_tool(query: str):
     """
     Retrieve relevant document chunks with citation IDs.
 
+    Args:
+        query:
+            The user's question (or sub-question).
+        document_scope:
+            If provided, restrict retrieval to chunks where metadata["source"] == document_scope.
+            This prevents citations from older PDFs.
+
     Returns:
-        content: citation-aware context string
-        artifact: citation map (chunk_id -> metadata)
+        content:
+            Citation-aware context string.
+        artifact:
+            Citation map (chunk_id -> metadata).
     """
-    # Retrieve more than we finally show, so we can dedupe and keep best variety
     fetch_k = 12
     top_n = 6
 

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 class QuestionRequest(BaseModel):
     """Request body for the `/qa` endpoint."""
     question: str
+    document_scope: Optional[str] = None
 
 
 class QAResponse(BaseModel):

--- a/backend/src/app/services/qa_service.py
+++ b/backend/src/app/services/qa_service.py
@@ -1,8 +1,21 @@
-"""Service layer for handling QA requests."""
+"""Service layer for handling QA requests.
+
+This layer acts as a stable interface between API and LangGraph pipeline.
+"""
 
 from typing import Dict, Any
 from ..core.agents.graph import run_qa_flow
 
 
-def answer_question(question: str) -> Dict[str, Any]:
-    return run_qa_flow(question)
+def answer_question(question: str, document_scope: str | None = None) -> Dict[str, Any]:
+    """
+    Execute the QA flow.
+
+    Args:
+        question: User question.
+        document_scope: Optional PDF filename to restrict retrieval.
+
+    Returns:
+        Dict with answer, context, citations, confidence...
+    """
+    return run_qa_flow(question, document_scope=document_scope)

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -21,7 +21,12 @@ export default function UploadPage() {
 
     try {
       setLoading(true);
+
       const res = await indexPdf(file);
+
+      // Save last uploaded filename for document-scoped retrieval
+      window.localStorage.setItem("intelirag:lastUploadedPdf", file.name);
+
       setStatus(res.message ?? res.status ?? "Indexed successfully");
       setChunks(typeof res.chunks_indexed === "number" ? res.chunks_indexed : null);
     } catch (e: unknown) {
@@ -37,14 +42,13 @@ export default function UploadPage() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Upload PDF</h1>
         <p className="mt-2 text-zinc-300/80">
-          Upload a PDF to index into Pinecone. After indexing, go back to <span className="font-semibold text-zinc-200">Ask</span>.
+          Upload a PDF to index into Pinecone. After indexing, go back to{" "}
+          <span className="font-semibold text-zinc-200">Ask</span>.
         </p>
       </div>
 
       <Card>
-        <CardHeader
-          title="Index a PDF"
-        />
+        <CardHeader title="Index a PDF" />
         <CardBody>
           <FileDropzone onFile={onFile} />
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,6 +1,6 @@
 /**
  * Shared API types for the frontend.
- * Keep these aligned with FastAPI response models.
+ * Keep these aligned with FastAPI request/response models.
  */
 
 export type CitationItem = {
@@ -8,6 +8,9 @@ export type CitationItem = {
   page_label?: string | number;
   source?: string;
   snippet?: string;
+
+  // optional full text if backend includes it
+  text?: string;
 };
 
 export type CitationsMap = Record<string, CitationItem>;
@@ -16,14 +19,6 @@ export type QAResponse = {
   answer: string;
   context: string;
   citations?: CitationsMap;
-
-  /**
-   * Confidence signal returned by the backend.
-   * Intended meaning:
-   * - high: multiple valid citations exist in final answer
-   * - medium: one valid citation exists in final answer
-   * - low: no valid citations exist in final answer
-   */
   confidence?: "high" | "medium" | "low";
 };
 
@@ -36,4 +31,10 @@ export type IndexPdfResponse = {
 
 export type QARequest = {
   question: string;
+
+  /**
+   * If provided, restrict retrieval to this document source name.
+   * If null/undefined, backend will search across all indexed PDFs.
+   */
+  document_scope?: string | null;
 };


### PR DESCRIPTION
- Add document_scope field and apply Pinecone metadata filter {"source": document_scope} during retrieval.
- Frontend provides scope toggle: All documents or Selected PDF (last uploaded).
- Backend API /qa accepts document_scope and passes it through LangGraph retrieval.
